### PR TITLE
Fix float bug in XLS converter

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -448,7 +448,7 @@ class XSheet:
             cell_type = self.wSheet.cell_type(curr_row, curr_cell)
             cell_value = self.wSheet.cell_value(curr_row, curr_cell)
 
-            if cell_type == xlrd.XL_CELL_BOOLEAN or cell_type == xlrd.XL_CELL_NUMBER:
+            if cell_type == xlrd.XL_CELL_BOOLEAN:
               try:
                 liste.append(str(int(cell_value)))
               except (ValueError, OverflowError):


### PR DESCRIPTION
Fixed a bug with the XLS converter that cast all floats to integers (e.g. 0.30% was changed to 0 value)
