### PR TITLE
Bump version of temp

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "underscore": "~1.4.4",
-    "temp": "~0.5.0",
+    "temp": "~0.8.0",
     "async": "~0.2.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Version 0.5.x of temp indirectly depends on a very old version of graceful-fs that does not work with Node.js 7.x or higher. A simple version bump seems to resolve the issue.